### PR TITLE
Update the eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
                 "caughtErrorsIgnorePattern": "^_"
             }
         ],
+        "indent": "warn",
         "@typescript-eslint/no-explicit-any": "error",
         "@typescript-eslint/no-unnecessary-condition": "off", // TODO: remove this rule
         "no-constant-condition": "off"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,9 +19,7 @@ jobs:
             - uses: actions/checkout@v3
             - run: yarn install --immutable
             - name: Restyle with prettier
-              uses: actionsx/prettier@v2
-              with:
-                  args: --write src/
+              run: prettier --write src/
             - name: Fix low-hanging eslint errors
               run: eslint --fix src/ || true
             - name: Run eslint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,9 +18,15 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - run: yarn install --immutable
-            - name: Compile
-              run: yarn build
+            - name: Restyle with prettier
+              uses: actionsx/prettier@v2
+              with:
+                  args: --write src/
+            - name: Fix low-hanging esling errors
+              run: eslint --fix src/ || true
             - name: Run eslint
               uses: mrdivyansh/eslint-action@v1.0.7
-            - name: Run prettier
-              uses: actionsx/prettier@v2
+              with:
+                  execute-on-files: src/
+            - name: Compile
+              run: yarn build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
               uses: actionsx/prettier@v2
               with:
                   args: --write src/
-            - name: Fix low-hanging esling errors
+            - name: Fix low-hanging eslint errors
               run: eslint --fix src/ || true
             - name: Run eslint
               uses: mrdivyansh/eslint-action@v1.0.7
@@ -30,3 +30,10 @@ jobs:
                   execute-on-files: src/
             - name: Compile
               run: yarn build
+            - name: Push
+              uses: actions-go/push@v1
+              with:
+                  author-email: github-actions[bot]@users.noreply.github.com
+                  author-name: Linter
+                  create-commit: true
+                  commit-message: "Reformatted code and fixed linting errors"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-package.json @Minion3665
+CODEOWNERS @Minion3665
 tsconfig.json @Minion3665
 .prettierrc.json @Minion3665
 .prettierignore @Minion3665
@@ -6,4 +6,3 @@ tsconfig.json @Minion3665
 .eslintignore @Minion3665
 .editorconfig @Minion3665
 .github/ @Minion3665
-

--- a/package.json
+++ b/package.json
@@ -28,11 +28,9 @@
     "scripts": {
         "build": "tsc",
         "start": "node --experimental-json-modules --enable-source-maps dist/index.js",
-        "dev": "rm -rf dist && eslint . --fix && tsc && node --experimental-json-modules --enable-source-maps dist/index.js",
-        "force-dev": "rm -rf dist && eslint . --fix; tsc-suppress && node --experimental-json-modules --enable-source-maps dist/index.js",
-        "lint": "echo 'Style checking...'; prettier --check .; echo 'Linting...'; eslint .; echo 'To auto-fix everything possible, please run `yarn lint-fix`'; true",
-        "lint-fix": "echo 'Fixing eslint issues...'; eslint . --fix; echo 'Reformatting...'; prettier --write --loglevel warn --cache .; true",
-        "lint-list": "echo 'Style checking...'; prettier --check .; echo 'Linting...'; eslint .; echo 'To view errors in more detail, please run `yarn lint`'; true",
+        "dev": "rm -rf dist && eslint src --fix && tsc && node --experimental-json-modules --enable-source-maps dist/index.js",
+        "force-dev": "rm -rf dist && eslint src --fix; tsc-suppress && node --experimental-json-modules --enable-source-maps dist/index.js",
+        "lint": "echo 'Reformatting...'; prettier --write --loglevel warn --cache src; echo 'Fixing eslint issues...'; eslint src --fix; true",
         "setup": "node Installer.js"
     },
     "repository": {


### PR DESCRIPTION
- Add back indenting to the eslint rules
- Make eslint always autofix after prettier
- Stop package.json being CODEOWNERed
- Remove all non-fixing lint scripts from package.json
- Update the github action to run prettier with eslint
- Make the github action push all fixes